### PR TITLE
Bumping database-proxy-1.4.3 + other dependency updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ target/
 .idea/
 *.iml
 *.tlog
+.classpath
+.project
+.settings/

--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
         <logback-ext-spring.version>0.1.1</logback-ext-spring.version>
 
         <aspectj.version>1.6.8</aspectj.version>
-        <spring.version>3.2.2.RELEASE</spring.version>
+        <spring.version>3.2.18.RELEASE</spring.version>
         <commons-lang.version>2.5</commons-lang.version>
         <datasource-proxy.version>1.3.1</datasource-proxy.version>
         <hibernate.version>4.3.9.Final</hibernate.version>

--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
 
         <aspectj.version>1.6.12</aspectj.version>
         <spring.version>3.2.18.RELEASE</spring.version>
-        <commons-lang.version>2.5</commons-lang.version>
+        <commons-lang.version>2.6</commons-lang.version>
         <datasource-proxy.version>1.3.3</datasource-proxy.version>
         <hibernate.version>4.3.11.Final</hibernate.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@
         <aspectj.version>1.6.12</aspectj.version>
         <spring.version>3.2.18.RELEASE</spring.version>
         <commons-lang.version>2.6</commons-lang.version>
-        <datasource-proxy.version>1.4.1</datasource-proxy.version>
+        <datasource-proxy.version>1.4.2</datasource-proxy.version>
         <hibernate.version>4.3.11.Final</hibernate.version>
 
         <mockito.version>1.10.19</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
         <hibernate.version>4.3.9.Final</hibernate.version>
 
         <mockito.version>1.8.5</mockito.version>
-        <junit.version>4.8.1</junit.version>
+        <junit.version>4.12</junit.version>
 
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>${maven-source-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -153,6 +154,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven-javadoc-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -165,6 +167,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
+                <version>${maven-gpg-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
@@ -200,6 +203,10 @@
 
         <mockito.version>1.8.5</mockito.version>
         <junit.version>4.8.1</junit.version>
+
+        <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
+        <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
+        <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
     </properties>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@
         <aspectj.version>1.6.12</aspectj.version>
         <spring.version>3.2.18.RELEASE</spring.version>
         <commons-lang.version>2.6</commons-lang.version>
-        <datasource-proxy.version>1.3.3</datasource-proxy.version>
+        <datasource-proxy.version>1.4.1</datasource-proxy.version>
         <hibernate.version>4.3.11.Final</hibernate.version>
 
         <mockito.version>1.10.19</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@
         <maven.compiler.target>1.6</maven.compiler.target>
 
         <jcl-over-slf4j.version>1.7.25</jcl-over-slf4j.version>
-        <logback.version>1.0.13</logback.version>
+        <logback.version>1.2.3</logback.version>
 
         <aspectj.version>1.6.12</aspectj.version>
         <spring.version>3.2.18.RELEASE</spring.version>

--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
         <maven.compiler.source>1.6</maven.compiler.source>
         <maven.compiler.target>1.6</maven.compiler.target>
 
-        <jcl-over-slf4j.version>1.6.1</jcl-over-slf4j.version>
+        <jcl-over-slf4j.version>1.6.6</jcl-over-slf4j.version>
         <logback.version>1.0.13</logback.version>
         <logback-ext-spring.version>0.1.1</logback-ext-spring.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
         <maven.compiler.source>1.6</maven.compiler.source>
         <maven.compiler.target>1.6</maven.compiler.target>
 
-        <jcl-over-slf4j.version>1.6.6</jcl-over-slf4j.version>
+        <jcl-over-slf4j.version>1.7.25</jcl-over-slf4j.version>
         <logback.version>1.0.13</logback.version>
 
         <aspectj.version>1.6.12</aspectj.version>

--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,6 @@
 
         <jcl-over-slf4j.version>1.6.6</jcl-over-slf4j.version>
         <logback.version>1.0.13</logback.version>
-        <logback-ext-spring.version>0.1.1</logback-ext-spring.version>
 
         <aspectj.version>1.6.8</aspectj.version>
         <spring.version>3.2.18.RELEASE</spring.version>

--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@
         <jcl-over-slf4j.version>1.6.6</jcl-over-slf4j.version>
         <logback.version>1.0.13</logback.version>
 
-        <aspectj.version>1.6.8</aspectj.version>
+        <aspectj.version>1.6.12</aspectj.version>
         <spring.version>3.2.18.RELEASE</spring.version>
         <commons-lang.version>2.5</commons-lang.version>
         <datasource-proxy.version>1.3.1</datasource-proxy.version>

--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@
         <spring.version>3.2.18.RELEASE</spring.version>
         <commons-lang.version>2.5</commons-lang.version>
         <datasource-proxy.version>1.3.1</datasource-proxy.version>
-        <hibernate.version>4.3.9.Final</hibernate.version>
+        <hibernate.version>4.3.11.Final</hibernate.version>
 
         <mockito.version>1.8.5</mockito.version>
         <junit.version>4.12</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@
         <datasource-proxy.version>1.3.3</datasource-proxy.version>
         <hibernate.version>4.3.11.Final</hibernate.version>
 
-        <mockito.version>1.8.5</mockito.version>
+        <mockito.version>1.10.19</mockito.version>
         <junit.version>4.12</junit.version>
 
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,11 @@
     </distributionManagement>
 
     <properties>
+        <java.version>1.6</java.version>
+        <maven.compiler.compilerVersion>1.6</maven.compiler.compilerVersion>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+
         <jcl-over-slf4j.version>1.6.1</jcl-over-slf4j.version>
         <logback.version>1.0.13</logback.version>
         <logback-ext-spring.version>0.1.1</logback-ext-spring.version>

--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@
         <aspectj.version>1.6.12</aspectj.version>
         <spring.version>3.2.18.RELEASE</spring.version>
         <commons-lang.version>2.5</commons-lang.version>
-        <datasource-proxy.version>1.3.1</datasource-proxy.version>
+        <datasource-proxy.version>1.3.3</datasource-proxy.version>
         <hibernate.version>4.3.11.Final</hibernate.version>
 
         <mockito.version>1.8.5</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@
         <aspectj.version>1.6.12</aspectj.version>
         <spring.version>3.2.18.RELEASE</spring.version>
         <commons-lang.version>2.6</commons-lang.version>
-        <datasource-proxy.version>1.4.2</datasource-proxy.version>
+        <datasource-proxy.version>1.4.3</datasource-proxy.version>
         <hibernate.version>4.3.11.Final</hibernate.version>
 
         <mockito.version>1.10.19</mockito.version>

--- a/src/main/java/com/vladmihalcea/sql/SQLStatementCountValidator.java
+++ b/src/main/java/com/vladmihalcea/sql/SQLStatementCountValidator.java
@@ -48,9 +48,9 @@ public class SQLStatementCountValidator {
      *
      * @param expectedSelectCount expected select statement count
      */
-    public static void assertSelectCount(int expectedSelectCount) {
+    public static void assertSelectCount(long expectedSelectCount) {
         QueryCount queryCount = QueryCountHolder.getGrandTotal();
-        int recordedSelectCount = queryCount.getSelect();
+        long recordedSelectCount = queryCount.getSelect();
         if (expectedSelectCount != recordedSelectCount) {
             throw new SQLSelectCountMismatchException(expectedSelectCount, recordedSelectCount);
         }
@@ -61,9 +61,9 @@ public class SQLStatementCountValidator {
      *
      * @param expectedInsertCount expected insert statement count
      */
-    public static void assertInsertCount(int expectedInsertCount) {
+    public static void assertInsertCount(long expectedInsertCount) {
         QueryCount queryCount = QueryCountHolder.getGrandTotal();
-        int recordedInsertCount = queryCount.getInsert();
+        long recordedInsertCount = queryCount.getInsert();
         if (expectedInsertCount != recordedInsertCount) {
             throw new SQLInsertCountMismatchException(expectedInsertCount, recordedInsertCount);
         }
@@ -74,9 +74,9 @@ public class SQLStatementCountValidator {
      *
      * @param expectedUpdateCount expected update statement count
      */
-    public static void assertUpdateCount(int expectedUpdateCount) {
+    public static void assertUpdateCount(long expectedUpdateCount) {
         QueryCount queryCount = QueryCountHolder.getGrandTotal();
-        int recordedUpdateCount = queryCount.getUpdate();
+        long recordedUpdateCount = queryCount.getUpdate();
         if (expectedUpdateCount != recordedUpdateCount) {
             throw new SQLUpdateCountMismatchException(expectedUpdateCount, recordedUpdateCount);
         }
@@ -87,9 +87,9 @@ public class SQLStatementCountValidator {
      *
      * @param expectedDeleteCount expected delete statement count
      */
-    public static void assertDeleteCount(int expectedDeleteCount) {
+    public static void assertDeleteCount(long expectedDeleteCount) {
         QueryCount queryCount = QueryCountHolder.getGrandTotal();
-        int recordedDeleteCount = queryCount.getDelete();
+        long recordedDeleteCount = queryCount.getDelete();
         if (expectedDeleteCount != recordedDeleteCount) {
             throw new SQLDeleteCountMismatchException(expectedDeleteCount, recordedDeleteCount);
         }

--- a/src/main/java/com/vladmihalcea/sql/exception/SQLDeleteCountMismatchException.java
+++ b/src/main/java/com/vladmihalcea/sql/exception/SQLDeleteCountMismatchException.java
@@ -8,7 +8,7 @@ package com.vladmihalcea.sql.exception;
  */
 public class SQLDeleteCountMismatchException extends SQLStatementCountMismatchException {
 
-    public SQLDeleteCountMismatchException(int expected, int recorded) {
+    public SQLDeleteCountMismatchException(long expected, long recorded) {
         super(expected, recorded);
     }
 }

--- a/src/main/java/com/vladmihalcea/sql/exception/SQLInsertCountMismatchException.java
+++ b/src/main/java/com/vladmihalcea/sql/exception/SQLInsertCountMismatchException.java
@@ -8,7 +8,7 @@ package com.vladmihalcea.sql.exception;
  */
 public class SQLInsertCountMismatchException extends SQLStatementCountMismatchException {
 
-    public SQLInsertCountMismatchException(int expected, int recorded) {
+    public SQLInsertCountMismatchException(long expected, long recorded) {
         super(expected, recorded);
     }
 }

--- a/src/main/java/com/vladmihalcea/sql/exception/SQLSelectCountMismatchException.java
+++ b/src/main/java/com/vladmihalcea/sql/exception/SQLSelectCountMismatchException.java
@@ -8,7 +8,7 @@ package com.vladmihalcea.sql.exception;
  */
 public class SQLSelectCountMismatchException extends SQLStatementCountMismatchException {
 
-    public SQLSelectCountMismatchException(int expected, int recorded) {
+    public SQLSelectCountMismatchException(long expected, long recorded) {
         super(expected, recorded);
     }
 }

--- a/src/main/java/com/vladmihalcea/sql/exception/SQLStatementCountMismatchException.java
+++ b/src/main/java/com/vladmihalcea/sql/exception/SQLStatementCountMismatchException.java
@@ -8,20 +8,20 @@ package com.vladmihalcea.sql.exception;
  */
 public abstract class SQLStatementCountMismatchException extends RuntimeException {
 
-    private final int expected;
-    private final int recorded;
+    private final long expected;
+    private final long recorded;
 
-    protected SQLStatementCountMismatchException(int expected, int recorded) {
+    protected SQLStatementCountMismatchException(long expected, long recorded) {
         super("Expected " + expected + " statements but recorded " + recorded + " instead!");
         this.expected = expected;
         this.recorded = recorded;
     }
 
-    public int getExpected() {
+    public long getExpected() {
         return expected;
     }
 
-    public int getRecorded() {
+    public long getRecorded() {
         return recorded;
     }
 }

--- a/src/main/java/com/vladmihalcea/sql/exception/SQLUpdateCountMismatchException.java
+++ b/src/main/java/com/vladmihalcea/sql/exception/SQLUpdateCountMismatchException.java
@@ -8,7 +8,7 @@ package com.vladmihalcea.sql.exception;
  */
 public class SQLUpdateCountMismatchException extends SQLStatementCountMismatchException {
 
-    public SQLUpdateCountMismatchException(int expected, int recorded) {
+    public SQLUpdateCountMismatchException(long expected, long recorded) {
         super(expected, recorded);
     }
 }


### PR DESCRIPTION
Hi Vlad

This PR adjusts db-util to the current verison of database-proxy.

On the way I was bumping other dependencies and ignored eclipse specific files.

I have all together 3 feature branches doing all this in dedicated steps. If you prefer to merge them istead of all in one go, just let me know.

Thanks and cheers
Urs